### PR TITLE
Capture files/folders operated on that should be deleted

### DIFF
--- a/ShareFileSnapIn/Parallel/UploadAction.cs
+++ b/ShareFileSnapIn/Parallel/UploadAction.cs
@@ -1,16 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Management.Automation;
-using System.Security.Cryptography;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using ShareFile.Api.Client.Exceptions;
 using ShareFile.Api.Client.FileSystem;
 using ShareFile.Api.Client.Transfers;
-using ShareFile.Api.Client.Transfers.Downloaders;
 using ShareFile.Api.Models;
 
 namespace ShareFile.Api.Powershell.Parallel

--- a/ShareFileSnapIn/ShareFileSnapIn.csproj
+++ b/ShareFileSnapIn/ShareFileSnapIn.csproj
@@ -41,19 +41,16 @@
     </AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="NLog">
       <HintPath>..\packages\NLog.3.1.0.0\lib\net45\NLog.dll</HintPath>
     </Reference>
-    <Reference Include="ShareFile.Api.Client.Core, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\ShareFile.Api.Client.3.0.9\lib\net45\ShareFile.Api.Client.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="ShareFile.Api.Client.Net45, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\ShareFile.Api.Client.3.0.9\lib\net45\ShareFile.Api.Client.Net45.dll</HintPath>
+    <Reference Include="ShareFile.Api.Client, Version=3.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ShareFile.Api.Client.3.3.1476\lib\net45\ShareFile.Api.Client.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration.Install" />
@@ -66,6 +63,7 @@
     </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Security" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/ShareFileSnapIn/packages.config
+++ b/ShareFileSnapIn/packages.config
@@ -1,8 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="log4net" version="2.0.3" targetFramework="net451" />
-  <package id="Newtonsoft.Json" version="6.0.3" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
   <package id="NLog" version="3.1.0.0" targetFramework="net451" />
-  <package id="ShareFile.Api.Client" version="3.0.9" targetFramework="net451" />
+  <package id="ShareFile.Api.Client" version="3.3.1476" targetFramework="net45" />
   <package id="System.Management.Automation" version="6.1.7601.17515" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Should solve #20 . Previously, two enumerations would happen when moving files from ShareFile to local.  First would in-situ download files and create respective folder structure.  The second, upon downloads completing, would happen as part of a single delete of source folders.  If new files and/or folders are added once the download operations begin, they will inadvertently be deleted.