### PR TITLE
Add logic to navigate to redirection uris using PSCredential objects 

### DIFF
--- a/ShareFileSnapIn/SendSfRequest.cs
+++ b/ShareFileSnapIn/SendSfRequest.cs
@@ -70,6 +70,12 @@ namespace ShareFile.Api.Powershell
         [Parameter]
         public string Account { get; set; }
 
+        [Parameter]
+        public bool Redirect { get; set; }
+
+        [Parameter]
+        public PSCredential Credential { get; set; }
+
         protected override void ProcessRecord()
         {
             if (Id != null && Uri != null) throw new Exception("Set only Id or Uri");
@@ -77,6 +83,18 @@ namespace ShareFile.Api.Powershell
             if (Action == null && Navigation != null) Action = Navigation;
             if (Method == null) Method = "GET";
             Method = Method.ToUpper();
+
+            if (Redirect)
+            {
+                if (Credential != null)
+                {
+                    Client.Client.AddCredentials(Uri, "Basic", Credential.GetNetworkCredential());
+                }
+                else
+                {
+                    throw new Exception("Parameter 'Credential' missing for a redirection uri.");
+                }
+            }
 
             Query<ODataObject> query = new Query<ODataObject>(Client.Client);
             query.HttpMethod = Method;

--- a/ShareFileSnapIn/ShareFileSnapIn.csproj
+++ b/ShareFileSnapIn/ShareFileSnapIn.csproj
@@ -49,7 +49,7 @@
       <HintPath>..\packages\NLog.3.1.0.0\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="ShareFile.Api.Client, Version=3.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ShareFile.Api.Client.3.3.1476\lib\net45\ShareFile.Api.Client.dll</HintPath>
+      <HintPath>..\packages\ShareFile.Api.Client.3.3.1597\lib\net45\ShareFile.Api.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/ShareFileSnapIn/packages.config
+++ b/ShareFileSnapIn/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
   <package id="NLog" version="3.1.0.0" targetFramework="net451" />
-  <package id="ShareFile.Api.Client" version="3.3.1476" targetFramework="net45" />
+  <package id="ShareFile.Api.Client" version="3.3.1597" targetFramework="net451" />
   <package id="System.Management.Automation" version="6.1.7601.17515" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Redirection URIs returned from ShareFile APIs need PSCredentials for further navigation since they belong to a different domain. This PR adds the logic to access the URIs using PSCredentials