### PR TITLE
Handling KeepFolders flag for the empty source folder(SFSDK-120)

### DIFF
--- a/ShareFileSnapIn/SyncSfItem.cs
+++ b/ShareFileSnapIn/SyncSfItem.cs
@@ -599,7 +599,7 @@ namespace ShareFile.Api.Powershell
                     FileAttributes attr = System.IO.File.GetAttributes(path);
                     FileSystemInfo source = ((attr & FileAttributes.Directory) == FileAttributes.Directory) ? new DirectoryInfo(path) : source = new FileInfo(path);
 
-                    DeleteLocalItemRecursive(source, Recursive);
+                    DeleteLocalItemRecursive(source, !KeepFolders);
                 }
             }
         }


### PR DESCRIPTION
In the method DeleteLocalItemRecursive(source, Recursive); Recursive being true was causing the empty source folder to be deleted. Passing !KeepFolders instead of Recursive will ensure the right behaviour for an empty source folder.