### PR TITLE
Fix for the issue where user gets null pointer exception while performing sync(download) operation with recursive=true

### DIFF
--- a/ShareFileSnapIn/SyncSfItem.cs
+++ b/ShareFileSnapIn/SyncSfItem.cs
@@ -306,6 +306,7 @@ namespace ShareFile.Api.Powershell
                             .Select("FileName")
                             .Select("FileSizeBytes")
                             .Select("Hash")
+                            .Select("Info")
                             .Execute();
 
                         foreach (var child in children.Feed)
@@ -385,6 +386,7 @@ namespace ShareFile.Api.Powershell
                     .Select("FileName")
                     .Select("FileSizeBytes")
                     .Select("Hash")
+                    .Select("Info")
                     .Execute();
 
                 if (children != null)


### PR DESCRIPTION
The issue was because we were not getting info for source folder's children and later we were trying to get information out of it (IsAHomeFolder) which was failing.
The actual reason for the exception was at line number 389 but I have incorporated the change at 309 as it also has a similar flow.