### PR TITLE
Possible fix for SFSDK-60

### DIFF
--- a/ShareFileSnapIn/SyncSfItem.cs
+++ b/ShareFileSnapIn/SyncSfItem.cs
@@ -820,8 +820,18 @@ namespace ShareFile.Api.Powershell
         /// </summary>
         private bool RemoveLocalItem(FileSystemInfo item)
         {
-            item.Delete();
-
+            try
+            { 
+                item.Delete();
+            }
+            catch (IOException ioe)
+            {
+                // File could not be deleted because it is locked.
+                // Calling Garbage collector explicitly to remove the object from the heap.
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                item.Delete();
+            }
             return true;
         }
 

--- a/ShareFileSnapIn/SyncSfItem.cs
+++ b/ShareFileSnapIn/SyncSfItem.cs
@@ -826,8 +826,8 @@ namespace ShareFile.Api.Powershell
             }
             catch (IOException ioe)
             {
-                // File could not be deleted because it is locked.
-                // Calling Garbage collector explicitly to remove the object from the heap.
+                // File could not be deleted because it is locked by an object present in heap.
+                // Calling Garbage collector explicitly to remove the object from the heap so as to unlock and delete the file.
                 GC.Collect();
                 GC.WaitForPendingFinalizers();
                 item.Delete();


### PR DESCRIPTION
UploadAction class, while uploading the file creates a reference and points to FileInfo object. This object stays in the heap even after the CopyFileItem method of class UploadAction goes out of scope. We cannot call dispose() method on FileInfo object as it does not implement IDispose interface. Hence we are calling Garbage Collector explicitly.